### PR TITLE
Change python-pyserial package

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ arch=('any')
 url="https://jeedom.fr"
 license=('GPL')
 depends=('ffmpeg' 'php-ssh' 'ntp' 'unzip' 'mariadb-clients' 'cronie'
-         'libmariadbclient' 'nodejs' 'php' 'php-fpm' 'usb_modeswitch' 'python-pyserial'
+         'libmariadbclient' 'nodejs' 'php' 'php-fpm' 'usb_modeswitch' 'python2-pyserial'
 	 'miniupnpc' 'npm' 'tinyxml' 'curl' 'php-ldap' 'nginx')
 optdepends=('mariadb')
 install=${pkgname}.install


### PR DESCRIPTION
python-pyserial use Python 3, Jeedom is not compatible. It is better to use the python 2-pyserial.
